### PR TITLE
add unusable image category

### DIFF
--- a/src/components/Legend.svelte
+++ b/src/components/Legend.svelte
@@ -6,6 +6,7 @@
 	import NoParkingLight from '../icons/legend/NoParkingLight.svelte';
 	import YesParking from '../icons/legend/YesParking.svelte';
 	import YesParkingLight from '../icons/legend/YesParkingLight.svelte';
+	import UnusableImage from '../icons/legend/UnusableImage.svelte';
 	import { simplifyFilters } from '../utils/basic-utils';
 
 	const filterValues = $derived(simplifyFilters(filterState.current));
@@ -56,6 +57,12 @@
 			</div>
 		</div>
 	{/if}
+	<div class="legend-item">
+		<div class="legend-text">Unusable Image:</div>
+		<div class="legend-icon">
+			<UnusableImage />
+		</div>
+	</div>
 </div>
 
 <style lang="scss">

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -196,6 +196,8 @@
 
 		return [
 			'case',
+			['to-boolean', ['get', 'unusableImage']],
+			widths.unusableCurbZoneWidth,
 			condition,
 			widths.curbZoneWidth,
 			widths.notAllowedCurbZoneWidth
@@ -209,6 +211,8 @@
 
 		return [
 			'case',
+			['to-boolean', ['get', 'unusableImage']],
+			dasharrays.unusableImageDasharray, // red dashed line
 			condition,
 			dasharrays.curbZoneDasharray, // solid line
 			dasharrays.notAllowedCurbZoneDasharray // dotted line
@@ -249,6 +253,8 @@
 
 		return [
 			'case',
+			['to-boolean', ['get', 'unusableImage']],
+			colors.unusableImage,
 			['boolean', ['feature-state', 'hover'], false],
 			colors.hoverHighlightColor,
 			condition,

--- a/src/constants.js
+++ b/src/constants.js
@@ -117,11 +117,13 @@ export const dasharrays = {
 	curbZoneDasharray: [1, 0], // solid line
 	notAllowedCurbZoneDasharray: [0.5, 2], // dotted line
 	areaSelectionDasharray: [2, 2],
+	unusableImageDasharray: [0.5, 2], // red dashed line
 };
 
 export const widths = {
 	curbZoneWidth: 5,
 	notAllowedCurbZoneWidth: 3,
+	unusableCurbZoneWidth: 3,
 	selectedCurbZoneStroke: 8,
 	selectedCurbZoneWidth: 4,
 	curbZoneEmphasisOutline: 12,
@@ -147,6 +149,7 @@ export const colors = {
 	//parkingNotAllowedLight: '#fcd9c0', //'#f9b685',
 	loading: '#e22214',
 	accessible: '#1871BD', // Optimistic Blue
+	unusableImage: '#a5a3a3', // Red
 	loadingIconFill: 'hsl(359, 95%, 75%)',
 	loadingIconStroke: 'hsl(0, 0%, 20%)',
 	accessibleIconFill: 'hsl(197, 71%, 73%)',

--- a/src/icons/legend/UnusableImage.svelte
+++ b/src/icons/legend/UnusableImage.svelte
@@ -1,0 +1,5 @@
+<svg width="100" height="20" viewBox="0 0 100 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="20" transform="matrix(1 0 0 -1 0 20)" fill="white"/>
+<path d="M10 10L96 10" stroke="#a5a3a3" stroke-width="5" stroke-linecap="round" stroke-dasharray="1 8"/>
+</svg>
+

--- a/src/utils/determine-parking-validity.js
+++ b/src/utils/determine-parking-validity.js
@@ -12,6 +12,7 @@ const determineParkingValidity = async (policies, zoneProperties, day, time) => 
 		permitted: false,
 		accessible: false,
 		loadingZone: false,
+		unusableImage: false,
 		// maxStay in minutes
 		maxStay: null,
 		paid: false
@@ -138,6 +139,12 @@ const determineParkingValidity = async (policies, zoneProperties, day, time) => 
 					// Check for loading zone
 					if (activity === 'loading' && validDayOfWeek && validTime) {
 						properties.loadingZone = true;
+					}
+
+					// Check for unusable image
+					if (activity === 'unusable image' ) {
+						console.log(("Got Unusable"))
+						properties.unusableImage = true;
 					}
 				}
 			}


### PR DESCRIPTION
This PR adds an "unusable image" category to the curb-atlas.

The new category is added to the legend and to the map symbology. It was tested with the Charlestown database run conducted the week of 4/20/2026.