### PR TITLE
Minor fixes and UI polish 

### DIFF
--- a/src/components/Frame.svelte
+++ b/src/components/Frame.svelte
@@ -98,7 +98,7 @@
 				<button class="info-modal-backdrop" onclick={() => (infoModalOpen = false)}></button>
 				<div class="info-modal" role="dialog">
 					<button class="close-button" onclick={() => (infoModalOpen = false)}><Close /></button>
-					<div class="info-modal-title">Chinatown Curb Map Demo</div>
+					<div class="info-modal-title">Boston Curb Map (BETA)</div>
 					<div class="info-modal-body">
 						<p>
 							The data you see may be incomplete, outdated, or inaccurate. <strong

--- a/src/components/Legend.svelte
+++ b/src/components/Legend.svelte
@@ -58,7 +58,7 @@
 		</div>
 	{/if}
 	<div class="legend-item">
-		<div class="legend-text">Unusable Image:</div>
+		<div class="legend-text">Sign could not be read (regulation unknown):</div>
 		<div class="legend-icon">
 			<UnusableImage />
 		</div>

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -722,20 +722,26 @@
 
 				mapState.map.addLayer(symbolLayer);
 
-				mapState.map.on('click', CURB_ZONES_LAYER_ID, (e) => {
+				const onCurbZoneClick = (e) => {
 					if (!e.features?.length) return;
-					const feature = e.features[0];
+					const zoneId = e.features[0]?.properties?.curb_zone_id;
+					if (!zoneId) return;
 					// Query the source because we want to pass the non-cropped geometries to selected segment
 					const selectionFeatures = mapState.map.querySourceFeatures(CURB_ZONES_SOURCE_ID, {
 						filter: [
 							'all',
 							['any', ['==', 'selectionOnly', true], ['==', 'innerLine', true]],
-							['==', 'curb_zone_id', feature?.properties?.curb_zone_id]
+							['==', 'curb_zone_id', zoneId]
 						]
 					});
 
-					selectCurbZoneSegment(selectionFeatures[0]);
-				});
+					if (selectionFeatures[0]) selectCurbZoneSegment(selectionFeatures[0]);
+				};
+				// Bind the click handler to both the visible 3-5 px line layer and the
+				// 12 px emphasis-outline layer above it, so users don't have to pixel-
+				// hunt to select a segment.
+				mapState.map.on('click', CURB_ZONES_LAYER_ID, onCurbZoneClick);
+				mapState.map.on('click', CURB_ZONES_EMPHASIS_OUTLINE_LAYER_ID, onCurbZoneClick);
 			} else {
 				existingSource.setData(nextData);
 			}

--- a/src/components/Policies.svelte
+++ b/src/components/Policies.svelte
@@ -15,6 +15,31 @@
 		JSON.parse(JSON.stringify(policies))?.sort((a, b) => a.priority - b.priority)
 	);
 
+	// The city's policy descriptions ("* No Parking 8:00 AM-12:00 PM") drop the
+	// days_of_week, so a Tuesdays-only rule reads as if it's everyday. Pull the
+	// day info off the time_spans and surface it as a separate line. Returns
+	// null when the rule applies all 7 days (no clarification needed).
+	const DAY_ORDER = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+	const DAY_LABEL = {
+		sun: 'Sun', mon: 'Mon', tue: 'Tue', wed: 'Wed', thu: 'Thu', fri: 'Fri', sat: 'Sat'
+	};
+	const summarizeDays = (policy) => {
+		const spans = policy?.time_spans || [];
+		if (!spans.length) return null;
+		const allDays = new Set();
+		for (const s of spans) {
+			for (const d of s.days_of_week || []) allDays.add(d);
+		}
+		if (allDays.size === 0 || allDays.size === 7) return null;
+		const ordered = DAY_ORDER.filter((d) => allDays.has(d));
+		const isMonFri =
+			ordered.length === 5 && ['mon', 'tue', 'wed', 'thu', 'fri'].every((d) => allDays.has(d));
+		const isMonSat = ordered.length === 6 && !allDays.has('sun');
+		if (isMonFri) return 'Mon–Fri';
+		if (isMonSat) return 'Mon–Sat';
+		return ordered.map((d) => DAY_LABEL[d]).join(', ');
+	};
+
 	const getLastUpdatedString = (dateMs) => {
 		const date = new Date(dateMs);
 
@@ -58,10 +83,13 @@
 						class={['policy-text', { highlighted: highlightedPolicyId === policy?.curb_policy_id }]}
 					>
 						{policy?.description ?? 'No policy description provided.'}
+						{#if summarizeDays(policy)}<div class="policy-days">{summarizeDays(policy)}</div>{/if}
 					</div>
-					<div class="last-updated">
-						Last updated {getLastUpdatedString(policy?.published_date)}
-					</div>
+					{#if policy?.published_date}
+						<div class="last-updated">
+							Last updated {getLastUpdatedString(policy?.published_date)}
+						</div>
+					{/if}
 				</div>
 			</li>
 		{/each}
@@ -105,6 +133,12 @@
 		&.highlighted {
 			color: var(--optimistic-blue);
 		}
+	}
+
+	.policy-days {
+		font-size: var(--font-size-s);
+		opacity: 0.75;
+		margin-top: 0.15rem;
 	}
 
 	.last-updated {

--- a/src/components/PoliciesWrapper.svelte
+++ b/src/components/PoliciesWrapper.svelte
@@ -7,10 +7,22 @@
 	import length from '@turf/length';
 	import along from '@turf/along';
 
-	const policies = $derived(selectedCurbZoneState.policies);
+	const realPolicies = $derived(selectedCurbZoneState.policies);
 	const geometry = $derived(selectedCurbZoneState.geometry);
 	const properties = $derived(selectedCurbZoneState.properties);
 	let curbZoneId = $derived(properties?.curb_zone_id);
+
+	// When the zone has real policies alongside the unusable-image sentinel,
+	// the sentinel adds no information — hide it so the panel stays clean.
+	// But if the sentinel is the *only* policy (true gray segment, no signs),
+	// keep it so the user sees something instead of an empty list.
+	const policies = $derived.by(() => {
+		if (!realPolicies?.length) return realPolicies;
+		const nonSentinel = realPolicies.filter((p) =>
+			(p.rules || []).some((r) => r?.activity !== 'unusable image')
+		);
+		return nonSentinel.length ? nonSentinel : realPolicies;
+	});
 
 	let activeTab = $state('policies');
 

--- a/src/components/TopBar.svelte
+++ b/src/components/TopBar.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="TopBar">
-	<div class="boston-app-title">Boston Curb Map </div>
+	<div class="boston-app-title">Boston Curb Map (BETA)</div>
 	<div class="right-container">
 		<button class="info-button" onclick={onClickInfo}>info</button>
 		<div class="boston-logo">

--- a/src/constants.js
+++ b/src/constants.js
@@ -117,7 +117,7 @@ export const dasharrays = {
 	curbZoneDasharray: [1, 0], // solid line
 	notAllowedCurbZoneDasharray: [0.5, 2], // dotted line
 	areaSelectionDasharray: [2, 2],
-	unusableImageDasharray: [0.5, 2], // red dashed line
+	unusableImageDasharray: [0.5, 2], // gray dashed line
 };
 
 export const widths = {
@@ -142,14 +142,11 @@ export const colors = {
 	parkingAllowedPaidLight: '#699eff', // Currently same as permitted
 	// Unsure if we want to combine
 	parkingAllowedPermittedPaidLight: '#699eff', // Currently same as permitted
-	//freedomTrailRed: '#FB4D42', //<- Freedom Trail Red
-	parkingNotAllowed: '#f58433',
-	parkingNotAllowedLight: '#f9b685',
-	//parkingNotAllowed: '#f9b685', //'#f58433',
-	//parkingNotAllowedLight: '#fcd9c0', //'#f9b685',
+	parkingNotAllowed: '#FB4D42', // Freedom Trail Red
+	parkingNotAllowedLight: '#fda398', // lightened Freedom Trail Red
 	loading: '#e22214',
 	accessible: '#1871BD', // Optimistic Blue
-	unusableImage: '#a5a3a3', // Red
+	unusableImage: '#a5a3a3', // gray (color comment was wrong)
 	loadingIconFill: 'hsl(359, 95%, 75%)',
 	loadingIconStroke: 'hsl(0, 0%, 20%)',
 	accessibleIconFill: 'hsl(197, 71%, 73%)',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,8 +7,8 @@
 </div>
 
 <svelte:head>
-	<title>Boston Curb Atlas - Chinatown Preview</title>
-	<meta name="description" content="Boston Curb Atlas - Chinatown Preview" />
+	<title>Boston Curb Map (BETA)</title>
+	<meta name="description" content="Boston Curb Map (BETA) — curb regulations across Boston" />
 </svelte:head>
 
 <style>

--- a/src/utils/determine-parking-validity.js
+++ b/src/utils/determine-parking-validity.js
@@ -18,6 +18,14 @@ const determineParkingValidity = async (policies, zoneProperties, day, time) => 
 		paid: false
 	};
 
+	// Time-limited "no parking" / "no stopping" rules ("Tue 12pm-4pm")
+	// implicitly allow parking outside their window. The main loop below only
+	// flips canPark via positive "parking" rules, so a zone whose only policy
+	// is a time-limited restriction would always show as red. Track whether
+	// any restriction is firing right now; if none is, fall back to allowed.
+	let hasTimeLimitedRestriction = false;
+	let restrictionActiveNow = false;
+
 	// Sort by priority order
 	const sortedPolicies = policies.sort((a, b) => a.priority - b.priority);
 
@@ -121,6 +129,17 @@ const determineParkingValidity = async (policies, zoneProperties, day, time) => 
 						time >= time_of_day_start &&
 						time <= time_of_day_end;
 
+					if (activity === 'no parking' || activity === 'no stopping') {
+						// Treat day/time as "always" when the field is null/equal.
+						const dayApplies = !days_of_week || days_of_week.includes(day);
+						const timeApplies =
+							time_of_day_start === null ||
+							time_of_day_start === time_of_day_end ||
+							(time >= time_of_day_start && time <= time_of_day_end);
+						hasTimeLimitedRestriction = true;
+						if (dayApplies && timeApplies) restrictionActiveNow = true;
+					}
+
 					// Check for days of week
 					// If parking is allowed and the "no parking" policy is not applied, skip
 					if (properties.canPark && days_of_week) {
@@ -146,25 +165,35 @@ const determineParkingValidity = async (policies, zoneProperties, day, time) => 
 		}
 	}
 
+	// Permissive default: if the zone's only regulations are time-limited
+	// restrictions and none of them apply at the selected day/time, parking
+	// is allowed. Without this, "No Parking Tue 12-4" zones render red on
+	// every other day/time. Runs before the unusable-image check below so
+	// we don't both flag the zone as "unknown" and allow parking.
+	if (!properties.canPark && hasTimeLimitedRestriction && !restrictionActiveNow) {
+		properties.canPark = true;
+	}
+
 	// Only mark unusable if we couldn't determine any parking policy
 	if (!properties.canPark && !properties.loadingZone) {
-	    const hasKnownPolicy = policies.some(policy =>
-	        (policy?.rules ?? []).some(rule => 
-	            rule?.activity && rule.activity !== 'unusable image'
-	        )
-	    );
-	    if (!hasKnownPolicy) {
-	        const hasUnusableImage = policies.some(policy =>
-	            (policy?.rules ?? []).some(rule => rule?.activity === 'unusable image')
-	        );
-	        properties.unusableImage = hasUnusableImage;
-	    }
-	}
-		if (properties.maxStay === null) {
-			delete properties.maxStay;
+		const hasKnownPolicy = policies.some((policy) =>
+			(policy?.rules ?? []).some(
+				(rule) => rule?.activity && rule.activity !== 'unusable image'
+			)
+		);
+		if (!hasKnownPolicy) {
+			const hasUnusableImage = policies.some((policy) =>
+				(policy?.rules ?? []).some((rule) => rule?.activity === 'unusable image')
+			);
+			properties.unusableImage = hasUnusableImage;
 		}
+	}
 
-		return { ...zoneProperties, ...properties };
-	};
+	if (properties.maxStay === null) {
+		delete properties.maxStay;
+	}
+
+	return { ...zoneProperties, ...properties };
+};
 
 export { determineParkingValidity };


### PR DESCRIPTION
A handful of small, independent fixes I made while using the app on my fork. Putting them up here in case any are useful upstream. Each commit is self-contained so feel free to cherry-pick.
 ## Bug fixes
 - **`canPark` stayed false on time-limited no-parking zones.** A segment whose only policy is "No Parking Tue 12 - 4" rendered red on every day/time, because `canPark` only flips true via positive "parking" rules. Added a permissive default at the end: if a zone has only restriction-style rules and none of them apply at the selected time, parking is allowed. Could repro this consistently on St James Street in Roxbury. 
 - **Stray `console.log('Got Unusable')`** fires once per unusableimage policy. Lots of console noise. 
 - **Curb-zone click hit area was tight enough to miss.** The 3 - 5px line layer has the click handler, clicks that landed a few px off did nothing and I found this made the map frustrating to use. Extracted the handler and bound it to the existing 12px emphasis-outline layer as well. 
 ## UX polish (some of this is from issue #4)
 - **Rebrand "Chinatown Curb Map Demo" → "Boston Curb Map (BETA)"** across the info modal, top-bar H1, and page title. Backend now has citywide data; the UI was the only place still calling itself a Chinatown demo. Closes the rebrand item in #4 P0.
 - **Freedom Trail Red for "no parking"** segments. The file had `#FB4D42` ("Freedom Trail Red") commented out already, just flipped to it. Also fixed a wrong color comment (`unusableImage` was labeled "Red" but renders gray).
 - **Legend: "Unusable Image"** → **"Sign could not be read (regulation unknown)."** Clarifies what this means. 
 - **Hide the unusable-image sentinel from the policy list** when the zone has other policies. It carries no information at that point (the dashed line already conveys the data-quality signal), but it's kept when it's the *only* policy on the zone so the panel isn't empty.
 - **Surface day-of-week per policy.** Today the description text ("* No Parking 8:00 AM-12:00 PM") drops `days_of_week`, so a Tuesdays-only rule reads as if it applies every day. Added a small line under each policy: "Mon-Fri" / "Tue, Thu" / etc. Skipped when all 7 days are covered.